### PR TITLE
fix: escape mdx variable ServiceLifetime

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -115,7 +115,7 @@ TODO:
 2. Asynchronous registration.
 3. Provide user-defined options.
 4. Replace service functionality
-5. Error less service registration via Try{ServiceLifetime} methods
+5. Error less service registration via `Try{ServiceLifetime}` methods
 
 ## Other third-party libraries
 


### PR DESCRIPTION
the mdx bundler will interpret {ServiceLifetime} as a variable, which is declared or initialised elsewhere.

If you intend to have the string Try{ServiceLifetime} in your docs, put it inside an inline code block.